### PR TITLE
chore: stop isolated Android Gradle Plugin Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     ignore:
-      # AGP 9 and Gradle 9 must ship together after a dedicated compatibility pass.
+      # AGP and Gradle must move together; isolated bumps fail this tree.
       - dependency-name: "com.android.application"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "gradle"
         update-types: ["version-update:semver-major"]
     groups:


### PR DESCRIPTION
#16 bumped AGP 8.5.2 → 8.13.2 without Gradle and failed plugin CI immediately. This ignores all `com.android.application` Dependabot updates until AGP and Gradle can move together.